### PR TITLE
should fix failing store test once the store status is figured out.

### DIFF
--- a/app/controllers/stores/items_controller.rb
+++ b/app/controllers/stores/items_controller.rb
@@ -6,7 +6,7 @@ class Stores::ItemsController < ApplicationController
   end
   
   def show
-		@item = Item.find(params[:id])
+    @item = Item.find(params[:id])
   end
 
   def new

--- a/app/controllers/stores_controller.rb
+++ b/app/controllers/stores_controller.rb
@@ -1,7 +1,7 @@
 class StoresController < ApplicationController
 
   def index
-    @stores = Store.all
+    @store = current_user.store
   end 
 
   def new
@@ -9,8 +9,7 @@ class StoresController < ApplicationController
   end 
 
   def create
-    @category = Category.new(title: params["store"]["name"] )
-    @category.save
+    store = Store.create(name: params["store"]["name"], user: current_user )
     redirect_to dashboard_index_path
   end
 

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20171215175846) do
+ActiveRecord::Schema.define(version: 20171215220535) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -75,7 +75,7 @@ ActiveRecord::Schema.define(version: 20171215175846) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.string "url"
-    t.integer "status", default: 0
+    t.string "status", default: "Pending"
     t.bigint "user_id"
     t.string "slug"
     t.index ["slug"], name: "index_stores_on_slug"


### PR DESCRIPTION
This fixes the 'user can create store' bug, except that stores are creating with status equal to nil. According to the migration, it should be initializing with an enum'd value of 0, but I ran the migrations and my schema is still showing "Pending" like we had before.  So the fact that it's initializing with nil is even weirder. @limsammy since you wrote the enum does it work on your machine? 

(Also, point of order: we had been running Store.all to feed our user index page but that seemed like it would allow us to pass our test but not actually work so I changed it to current_user.store...let me know if I'm missing something.)

*UPDATE* I dropped/reset my database and the test is now passing. Weird.  @jmejia is there a standardized way of dealing with git stuff involving changes to the DB? Should you always reset whenever you pull down a branch with db changes?

